### PR TITLE
remove bash-specific pushd/popd usage

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,11 +32,10 @@ echo ""
 cp ./loader.js /tmp/loader.js
 echo -e "/**\n* @provides sourcegraph\n*/\n\nwindow.SOURCEGRAPH_PHABRICATOR_EXTENSION = true;\nwindow.SOURCEGRAPH_URL = '$(echo $2)';\n" >/tmp/base.js
 
-pushd $1
+cd $1
 mkdir -p ./webroot/rsrc/js/sourcegraph
 cat /tmp/base.js /tmp/loader.js >./webroot/rsrc/js/sourcegraph/sourcegraph.js
 ./bin/celerity map
-popd
 
 echo "Success!"
 echo ""

--- a/install_loader.sh
+++ b/install_loader.sh
@@ -10,11 +10,10 @@ fi
 cp ./loader.js /tmp/loader.js
 echo -e "/**\n* @provides sourcegraph\n*/\n\nwindow.SOURCEGRAPH_PHABRICATOR_EXTENSION = true;\nwindow.SOURCEGRAPH_URL = '$(echo $2)';\n" >/tmp/base.js
 
-pushd $1
+cd $1
 mkdir -p ./webroot/rsrc/js/sourcegraph
 cat /tmp/base.js /tmp/loader.js >./webroot/rsrc/js/sourcegraph/sourcegraph.js
 ./bin/celerity map
-popd
 
 echo "Success!"
 echo ""


### PR DESCRIPTION
The script's shebang is `#!/bin/sh`, so bash-specific commands such as `pushd` and `popd` are not allowed. They may work under some bash configurations, but they do not work on the default Ubuntu bash. Also, they would not work on a non-bash shell (as many Phabricator machines are likely to be running, like alpine or busybox).