### PR TITLE
Check CSP exists and use PhabricatorConfigJSONOptionType to support January 2017

### DIFF
--- a/src/application/SourcegraphApplication.php
+++ b/src/application/SourcegraphApplication.php
@@ -30,9 +30,12 @@ final class SourcegraphApplication extends PhabricatorApplication
 
         // In order to load the Sourcegraph Phabricator bundle and to fetch content from a Sourcegraph Server
         // instance, the CSP policy must include the Sourcegraph Server instance url.
+        $resource = new CelerityStaticResourceResponse();
+        if (method_exists($resource, 'addContentSecurityPolicyURI') && is_callable(array($resource, 'addContentSecurityPolicyURI'))) {
         CelerityAPI::getStaticResourceResponse()
             ->addContentSecurityPolicyURI('connect-src', $url)
             ->addContentSecurityPolicyURI('script-src', $url);
+        }
 
         Javelin::initBehavior('sourcegraph-config', array(
             'bundleUrl' => $bundleUrl,

--- a/src/config/SourcegraphCallsignMappingConfigType.php
+++ b/src/config/SourcegraphCallsignMappingConfigType.php
@@ -1,13 +1,12 @@
 <?php
 
-final class SourcegraphCallsignMappingConfigType extends PhabricatorJSONConfigType
+final class SourcegraphCallsignMappingConfigType extends PhabricatorConfigJSONOptionType
 {
 
     const TYPEKEY = 'sourcegraph.callsignMapping';
 
-    public function validateStoredValue(
-        PhabricatorConfigOption $option,
-        $value) {
+    public function validateOption(PhabricatorConfigOption $option, $value)
+    {
         foreach ($value as $index => $spec) {
             if (!is_array($spec)) {
                 throw $this->newException(
@@ -20,19 +19,19 @@ final class SourcegraphCallsignMappingConfigType extends PhabricatorJSONConfigTy
         }
         foreach ($value as $index => $spec) {
             try {
-              PhutilTypeSpec::checkMap(
-                $spec,
-                array(
-                  'callsign' => 'string',
-                  'path' => 'string',
-                ));
+                PhutilTypeSpec::checkMap(
+                    $spec,
+                    array(
+                        'callsign' => 'string',
+                        'path' => 'string',
+                    ));
             } catch (Exception $ex) {
-              throw $this->newException(
-                pht(
-                  'Sourcegraph callsign mapping configuration has an invalid mapping '.
-                  'specification (at index "%s"): %s.',
-                  $index,
-                  $ex->getMessage()));
+                throw $this->newException(
+                    pht(
+                        'Sourcegraph callsign mapping configuration has an invalid mapping ' .
+                        'specification (at index "%s"): %s.',
+                        $index,
+                        $ex->getMessage()));
             }
         }
     }

--- a/src/config/SourcegraphConfigOptions.php
+++ b/src/config/SourcegraphConfigOptions.php
@@ -24,7 +24,7 @@ final class PhabricatorSourcegraphConfigOptions extends PhabricatorApplicationCo
 
     public function getOptions()
     {
-        $callsign_mapping_type = 'sourcegraph.callsignMapping';
+        $callsign_mapping_type = 'custom:SourcegraphCallsignMappingConfigType';
 
         return array(
             $this->newOption(


### PR DESCRIPTION
- Checks for the existence of the CSP function `addContentSecurityPolicyURI`
- Uses `PhabricatorConfigJSONOptionType` to support all versions released in 2017