### PR TITLE
Add TypeKey getter to SourcegraphCallsignMappingConfigType

### DIFF
--- a/src/config/SourcegraphCallsignMappingConfigType.php
+++ b/src/config/SourcegraphCallsignMappingConfigType.php
@@ -35,4 +35,13 @@ final class SourcegraphCallsignMappingConfigType extends PhabricatorConfigJSONOp
             }
         }
     }
+
+    public function validateStoredValue(PhabricatorConfigOption $option, $value) {
+        return validateOption($option, $value);
+    }
+
+    final public function getTypeKey()
+    {
+        return $this->getPhobjectClassConstant('TYPEKEY');
+    }
 }


### PR DESCRIPTION
To support legacy Phabricator versions (beginning of 2017) as well as the newest Phabricator version our JSON config class must extend `PhabricatorConfigJSONOptionType` instead of `PhabricatorJSONConfigType`. Newer versions require `getTypeKey` which is not implemented in `PhabricatorConfigJSONOptionType`