### PR TITLE
Add frame-src CSP directive

### DIFF
--- a/src/application/SourcegraphApplication.php
+++ b/src/application/SourcegraphApplication.php
@@ -39,6 +39,7 @@ final class SourcegraphApplication extends PhabricatorApplication
         if (method_exists($resource, 'addContentSecurityPolicyURI') && is_callable(array($resource, 'addContentSecurityPolicyURI'))) {
             CelerityAPI::getStaticResourceResponse()
                 ->addContentSecurityPolicyURI('connect-src', $url)
+                ->addContentSecurityPolicyURI('frame-src', $url)
                 ->addContentSecurityPolicyURI('script-src', $url);
         }
 


### PR DESCRIPTION
Rel https://github.com/sourcegraph/sourcegraph/pull/4187, https://github.com/sourcegraph/sourcegraph/issues/2415

Adds a CSP directive allowing to load iframes from the Sourcegraph instance, this is necessary now that the extension host worker is run from within an iframe.